### PR TITLE
feat: 검수 요청 작품 삭제 기능 구현

### DIFF
--- a/src/main/java/com/speaktext/backend/author/exception/AuthorExceptionType.java
+++ b/src/main/java/com/speaktext/backend/author/exception/AuthorExceptionType.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum AuthorExceptionType implements BaseExceptionType {
+
     ALREADY_EXISTS_AUTHOR_ID(CONFLICT, "이미 존재하는 작가 ID입니다."),
     ;
 

--- a/src/main/java/com/speaktext/backend/book/application/BookInspectionService.java
+++ b/src/main/java/com/speaktext/backend/book/application/BookInspectionService.java
@@ -5,6 +5,7 @@ import com.speaktext.backend.book.application.dto.BookInspectionMetaResponse;
 import com.speaktext.backend.book.domain.PendingBook;
 import com.speaktext.backend.book.domain.repository.PendingBookRepository;
 import com.speaktext.backend.book.domain.repository.RawTextStorage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,15 +13,11 @@ import java.util.List;
 import static com.speaktext.backend.common.util.FileReader.readTxtFile;
 
 @Service
+@RequiredArgsConstructor
 public class BookInspectionService {
 
     private final RawTextStorage rawTextStorage;
     private final PendingBookRepository pendingBookRepository;
-
-    public BookInspectionService(RawTextStorage rawTextStorage, PendingBookRepository pendingBookRepository) {
-        this.rawTextStorage = rawTextStorage;
-        this.pendingBookRepository = pendingBookRepository;
-    }
 
     public void requestInspection(BookInspectionCommand command, Long authorId) {
         String rawText = readTxtFile(command.txtFile());
@@ -80,5 +77,4 @@ public class BookInspectionService {
     public String getRawText(String identificationNumber) {
         return rawTextStorage.load(identificationNumber);
     }
-
 }

--- a/src/main/java/com/speaktext/backend/book/application/PendingBookService.java
+++ b/src/main/java/com/speaktext/backend/book/application/PendingBookService.java
@@ -21,7 +21,7 @@ public class PendingBookService {
     public void deleteRawTextAndPendingBook(@NotBlank String identificationNumber) {
         validatePendingBook(identificationNumber);
 
-        String rawTextBackup = backupRawTextOrThrow(identificationNumber);
+        String rawTextBackup = rawTextStorage.load(identificationNumber);
 
         rawTextStorage.delete(identificationNumber);
 
@@ -34,14 +34,6 @@ public class PendingBookService {
 
         if (book.getInspectionStatus() != PendingBook.InspectionStatus.PENDING) {
             throw new PendingBookException(PENDING_BOOK_NOT_IN_PENDING_STATUS);
-        }
-    }
-
-    private String backupRawTextOrThrow(String identificationNumber) {
-        try {
-            return rawTextStorage.load(identificationNumber);
-        } catch (Exception e) {
-            throw new IllegalStateException("원문 백업 실패", e);
         }
     }
 

--- a/src/main/java/com/speaktext/backend/book/application/PendingBookService.java
+++ b/src/main/java/com/speaktext/backend/book/application/PendingBookService.java
@@ -1,0 +1,64 @@
+package com.speaktext.backend.book.application;
+
+import com.speaktext.backend.book.domain.PendingBook;
+import com.speaktext.backend.book.domain.repository.PendingBookRepository;
+import com.speaktext.backend.book.domain.repository.RawTextStorage;
+import com.speaktext.backend.book.exception.PendingBookException;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.speaktext.backend.book.exception.PendingBookExceptionType.*;
+
+@Service
+@RequiredArgsConstructor
+public class PendingBookService {
+    private final RawTextStorage rawTextStorage;
+    private final PendingBookRepository pendingBookRepository;
+
+    @Transactional
+    public void deleteRawTextAndPendingBook(@NotBlank String identificationNumber) {
+        validatePendingBook(identificationNumber);
+
+        String rawTextBackup = backupRawTextOrThrow(identificationNumber);
+
+        rawTextStorage.delete(identificationNumber);
+
+        deletePendingBookOrRollback(identificationNumber, rawTextBackup);
+    }
+
+    private void validatePendingBook(String identificationNumber) {
+        PendingBook book = pendingBookRepository.findByIdentificationNumber(identificationNumber);
+        if (book == null) throw new PendingBookException(PENDING_BOOK_NOT_FOUND);
+
+        if (book.getInspectionStatus() != PendingBook.InspectionStatus.PENDING) {
+            throw new PendingBookException(PENDING_BOOK_NOT_IN_PENDING_STATUS);
+        }
+    }
+
+    private String backupRawTextOrThrow(String identificationNumber) {
+        try {
+            return rawTextStorage.load(identificationNumber);
+        } catch (Exception e) {
+            throw new IllegalStateException("원문 백업 실패", e);
+        }
+    }
+
+    private void deletePendingBookOrRollback(String identificationNumber, String rawTextBackup) {
+        try {
+            pendingBookRepository.deleteByIdentificationNumber(identificationNumber);
+        } catch (Exception deletionException) {
+            attemptRollback(identificationNumber, rawTextBackup, deletionException);
+        }
+    }
+
+    private void attemptRollback(String identificationNumber, String rawTextBackup, Exception cause) {
+        try {
+            rawTextStorage.save(rawTextBackup, identificationNumber);
+        } catch (Exception rollbackException) {
+            throw new IllegalStateException("원문 삭제 후 원문 복구도 실패", rollbackException);
+        }
+        throw new IllegalStateException("PendingBook 삭제 실패, 원문은 롤백 완료됨", cause);
+    }
+}

--- a/src/main/java/com/speaktext/backend/book/domain/infra/impl/PendingBookJpaRepository.java
+++ b/src/main/java/com/speaktext/backend/book/domain/infra/impl/PendingBookJpaRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface PendingBookJpaRepository extends JpaRepository<PendingBook, Long> {
 
     List<PendingBook> findByInspectionStatus(PendingBook.InspectionStatus inspectionStatus);
-
+    PendingBook findByIdentificationNumber(String identificationNumber);
+    void deleteByIdentificationNumber(String identificationNumber);
 }

--- a/src/main/java/com/speaktext/backend/book/domain/infra/impl/PendingBookRepositoryImpl.java
+++ b/src/main/java/com/speaktext/backend/book/domain/infra/impl/PendingBookRepositoryImpl.java
@@ -25,4 +25,14 @@ public class PendingBookRepositoryImpl implements PendingBookRepository {
         return pendingBookJpaRepository.findByInspectionStatus(PendingBook.InspectionStatus.PENDING);
     }
 
+    @Override
+    public PendingBook findByIdentificationNumber(String identificationNumber) {
+        return pendingBookJpaRepository.findByIdentificationNumber(identificationNumber);
+    }
+
+    @Override
+    public void deleteByIdentificationNumber(String identificationNumber) {
+        pendingBookJpaRepository.deleteByIdentificationNumber(identificationNumber);
+    }
+
 }

--- a/src/main/java/com/speaktext/backend/book/domain/repository/PendingBookRepository.java
+++ b/src/main/java/com/speaktext/backend/book/domain/repository/PendingBookRepository.java
@@ -1,11 +1,14 @@
 package com.speaktext.backend.book.domain.repository;
 
 import com.speaktext.backend.book.domain.PendingBook;
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.List;
 
 public interface PendingBookRepository {
 
     void save(PendingBook pendingBook);
     List<PendingBook> findPendingBooks();
-
+    PendingBook findByIdentificationNumber(String identificationNumber);
+    void deleteByIdentificationNumber(@NotBlank String identificationNumber);
 }

--- a/src/main/java/com/speaktext/backend/book/exception/PendingBookException.java
+++ b/src/main/java/com/speaktext/backend/book/exception/PendingBookException.java
@@ -1,0 +1,16 @@
+package com.speaktext.backend.book.exception;
+
+import com.speaktext.backend.common.exception.BaseException;
+import com.speaktext.backend.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PendingBookException extends BaseException {
+
+    private final PendingBookExceptionType pendingBookExceptionType;
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return pendingBookExceptionType;
+    }
+}

--- a/src/main/java/com/speaktext/backend/book/exception/PendingBookExceptionType.java
+++ b/src/main/java/com/speaktext/backend/book/exception/PendingBookExceptionType.java
@@ -1,0 +1,25 @@
+package com.speaktext.backend.book.exception;
+
+import com.speaktext.backend.common.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum PendingBookExceptionType implements BaseExceptionType {
+    PENDING_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "대기 도서를 찾을 수 없습니다."),
+    PENDING_BOOK_NOT_IN_PENDING_STATUS(HttpStatus.BAD_REQUEST,  "대기 도서가 Pending 상태가 아닙니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/speaktext/backend/book/exception/PendingBookExceptionType.java
+++ b/src/main/java/com/speaktext/backend/book/exception/PendingBookExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum PendingBookExceptionType implements BaseExceptionType {
+
     PENDING_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "대기 도서를 찾을 수 없습니다."),
     PENDING_BOOK_NOT_IN_PENDING_STATUS(HttpStatus.BAD_REQUEST,  "대기 도서가 Pending 상태가 아닙니다."),
     ;

--- a/src/main/java/com/speaktext/backend/book/presentation/BookInspectionController.java
+++ b/src/main/java/com/speaktext/backend/book/presentation/BookInspectionController.java
@@ -8,6 +8,7 @@ import com.speaktext.backend.book.application.mapper.BookInspectionMapper;
 import com.speaktext.backend.book.presentation.dto.BookInspectionRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,15 +16,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/book")
+@RequiredArgsConstructor
 public class BookInspectionController {
 
     private final BookInspectionService bookInspectionService;
     private final BookInspectionMapper bookInspectionMapper;
-
-    public BookInspectionController(BookInspectionService bookInspectionService, BookInspectionMapper bookInspectionMapper) {
-        this.bookInspectionService = bookInspectionService;
-        this.bookInspectionMapper = bookInspectionMapper;
-    }
 
     @PostMapping("/inspection")
     public ResponseEntity<Void> requestPendingBook(

--- a/src/main/java/com/speaktext/backend/book/presentation/PendingBookController.java
+++ b/src/main/java/com/speaktext/backend/book/presentation/PendingBookController.java
@@ -1,0 +1,28 @@
+package com.speaktext.backend.book.presentation;
+
+import com.speaktext.backend.auth.presentation.anotation.Author;
+import com.speaktext.backend.book.application.PendingBookService;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/book/pending")
+public class PendingBookController {
+
+    private final PendingBookService pendingBookService;
+
+    @DeleteMapping("/{identificationNumber}")
+    public ResponseEntity<Void> deleteRawText(
+            @Author Long adminId,
+            @PathVariable @NotBlank String identificationNumber
+    ) {
+        pendingBookService.deleteRawTextAndPendingBook(identificationNumber);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/speaktext/backend/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/speaktext/backend/member/exception/MemberExceptionType.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum MemberExceptionType implements BaseExceptionType {
+
     ALREADY_EXISTS_MEMBER_ID(CONFLICT, "이미 존재하는 멤버 ID입니다."),;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 

## 📝작업 내용

> 검수 요청 작품에 대한 삭제 기능을 구현하였습니다.
JPA 삭제 실패 시 MongoDB 롤백 절차를 추가하여 보상 트랜잭션을 적용하였습니다.


