### PR TITLE
feat: 스크립트 가져오기 페이지네이션 구현

### DIFF
--- a/src/main/java/com/speaktext/backend/book/application/ScriptSearcher.java
+++ b/src/main/java/com/speaktext/backend/book/application/ScriptSearcher.java
@@ -6,6 +6,8 @@ import com.speaktext.backend.book.domain.repository.ScriptFragmentRepository;
 import com.speaktext.backend.book.domain.repository.ScriptRepository;
 import com.speaktext.backend.book.exception.BookException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -42,8 +44,8 @@ public class ScriptSearcher {
         return script.getAuthorId().equals(authorId);
     }
 
-    public List<Script> findAllScriptOfAuthor(Long authorId) {
-        return scriptRepository.findByAuthorId(authorId);
+    public Page<Script> findByAuthorIdAndIsCompleted(Long authorId, boolean isCompleted, Pageable pageable) {
+        return scriptRepository.findByAuthorIdAndIsCompleted(authorId, isCompleted, pageable);
     }
 
 }

--- a/src/main/java/com/speaktext/backend/book/application/ScriptTransformationService.java
+++ b/src/main/java/com/speaktext/backend/book/application/ScriptTransformationService.java
@@ -5,6 +5,9 @@ import com.speaktext.backend.book.application.dto.ScriptResponse;
 import com.speaktext.backend.book.domain.PendingBookChunks;
 import com.speaktext.backend.book.domain.Script;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -36,11 +39,10 @@ public class ScriptTransformationService {
                 .toList();
     }
 
-    public List<ScriptMetaResponse> getAuthorScripts(Long authorId) {
-        var scripts = scriptSearcher.findAllScriptOfAuthor(authorId);
-        return scripts.stream()
-                .map(ScriptMetaResponse::from)
-                .toList();
+    public Page<ScriptMetaResponse> getAuthorScripts(Long authorId, boolean isCompleted, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Script> scripts = scriptSearcher.findByAuthorIdAndIsCompleted(authorId, isCompleted, pageable);
+        return scripts.map(ScriptMetaResponse::from);
     }
 
 }

--- a/src/main/java/com/speaktext/backend/book/domain/repository/ScriptRepository.java
+++ b/src/main/java/com/speaktext/backend/book/domain/repository/ScriptRepository.java
@@ -1,14 +1,15 @@
 package com.speaktext.backend.book.domain.repository;
 
 import com.speaktext.backend.book.domain.Script;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ScriptRepository {
 
     Script save(Script script);
     Optional<Script> findByIdentificationNumber(String identificationNumber);
-    List<Script> findByAuthorId(Long authorId);
+    Page<Script> findByAuthorIdAndIsCompleted(Long authorId, boolean isCompleted, Pageable pageable);
 
 }

--- a/src/main/java/com/speaktext/backend/book/infra/core/impl/ScriptJpaRepository.java
+++ b/src/main/java/com/speaktext/backend/book/infra/core/impl/ScriptJpaRepository.java
@@ -1,14 +1,15 @@
 package com.speaktext.backend.book.infra.core.impl;
 
 import com.speaktext.backend.book.domain.Script;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ScriptJpaRepository extends JpaRepository<Script, Long> {
 
     Optional<Script> findByIdentificationNumber(String identificationNumber);
-    List<Script> findByAuthorId(Long authorId);
+    Page<Script> findByAuthorIdAndIsCompleted(Long authorId, boolean isCompleted, Pageable pageable);
 
 }

--- a/src/main/java/com/speaktext/backend/book/infra/core/impl/ScriptRepositoryImpl.java
+++ b/src/main/java/com/speaktext/backend/book/infra/core/impl/ScriptRepositoryImpl.java
@@ -3,9 +3,10 @@ package com.speaktext.backend.book.infra.core.impl;
 import com.speaktext.backend.book.domain.Script;
 import com.speaktext.backend.book.domain.repository.ScriptRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -25,8 +26,8 @@ public class ScriptRepositoryImpl implements ScriptRepository {
     }
 
     @Override
-    public List<Script> findByAuthorId(Long authorId) {
-        return scriptJpaRepository.findByAuthorId(authorId);
+    public Page<Script> findByAuthorIdAndIsCompleted(Long authorId, boolean isCompleted, Pageable pageable) {
+        return scriptJpaRepository.findByAuthorIdAndIsCompleted(authorId, isCompleted, pageable);
     }
 
 }

--- a/src/main/java/com/speaktext/backend/book/presentation/ScriptTransformationController.java
+++ b/src/main/java/com/speaktext/backend/book/presentation/ScriptTransformationController.java
@@ -46,7 +46,6 @@ public class ScriptTransformationController {
             @RequestParam(defaultValue = "8") int size
     ) {
         var authorInProgressScripts = scriptTransformationService.getAuthorScripts(authorId, false, page, size);
-        System.out.println(authorInProgressScripts);
         return ResponseEntity.ok(authorInProgressScripts);
     }
 

--- a/src/main/java/com/speaktext/backend/book/presentation/ScriptTransformationController.java
+++ b/src/main/java/com/speaktext/backend/book/presentation/ScriptTransformationController.java
@@ -8,6 +8,7 @@ import com.speaktext.backend.book.application.dto.ScriptResponse;
 import com.speaktext.backend.book.presentation.dto.ScriptGetRequest;
 import com.speaktext.backend.book.presentation.dto.ScriptRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,12 +39,25 @@ public class ScriptTransformationController {
         return ResponseEntity.ok(script);
     }
 
-    @GetMapping("/progress")
-    public ResponseEntity<List<ScriptMetaResponse>> getScriptProgress(
-            @Author Long authorId
+    @GetMapping("/progress/in-progress")
+    public ResponseEntity<Page<ScriptMetaResponse>> getInProgressScripts(
+            @Author Long authorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size
     ) {
-        var authorScripts = scriptTransformationService.getAuthorScripts(authorId);
-        return ResponseEntity.ok(authorScripts);
+        var authorInProgressScripts = scriptTransformationService.getAuthorScripts(authorId, false, page, size);
+        System.out.println(authorInProgressScripts);
+        return ResponseEntity.ok(authorInProgressScripts);
+    }
+
+    @GetMapping("/progress/completed")
+    public ResponseEntity<Page<ScriptMetaResponse>> getCompletedScrips(
+            @Author Long authorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size
+    ) {
+        var authorCompletedScripts = scriptTransformationService.getAuthorScripts(authorId, true, page, size);
+        return ResponseEntity.ok(authorCompletedScripts);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 

## 📝작업 내용

> 스크립트 가져오기 페이지네이션 구현
기존에 하나만 존재하던 api를 둘로 나누어 완료된 스크립트와 진행중인 스크립트를 Page 객체로 전달
JPA의 Pageable 사용

### 스크린샷 (선택)
![스크린샷 2025-05-11 오후 5 09 02](https://github.com/user-attachments/assets/e66b6284-16e8-4485-b408-a6a7e5353adc)
