### PR TITLE
feat: coverUrl 저장 기능 추가

### DIFF
--- a/src/main/java/com/speaktext/backend/book/infra/cover/ImageStorage.java
+++ b/src/main/java/com/speaktext/backend/book/infra/cover/ImageStorage.java
@@ -1,0 +1,10 @@
+package com.speaktext.backend.book.infra.cover;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Path;
+
+public interface ImageStorage {
+
+    Path saveImage(MultipartFile image);
+}

--- a/src/main/java/com/speaktext/backend/book/infra/cover/LocalImageStorage.java
+++ b/src/main/java/com/speaktext/backend/book/infra/cover/LocalImageStorage.java
@@ -1,0 +1,44 @@
+package com.speaktext.backend.book.infra.cover;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Component
+public class LocalImageStorage implements ImageStorage {
+
+    private static final String OUTPUT_DIR = "coverImages";
+
+    @Override
+    public Path saveImage(MultipartFile image) {
+        try {
+            Path outputDir = Paths.get(OUTPUT_DIR);
+            if (Files.notExists(outputDir)) {
+                Files.createDirectories(outputDir);
+            }
+
+            String originalFilename = image.getOriginalFilename();
+            String extension = "";
+
+            if (originalFilename != null && originalFilename.contains(".")) {
+                extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+            }
+
+            String filename = UUID.randomUUID() + extension;
+            Path targetPath = outputDir.resolve(filename);
+
+            Files.copy(image.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            return targetPath;
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/speaktext/backend/book/inspection/application/mapper/BookInspectionMapper.java
+++ b/src/main/java/com/speaktext/backend/book/inspection/application/mapper/BookInspectionMapper.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class BookInspectionMapper {
 
-    public BookInspectionCommand toCommand(BookInspectionRequest request) {
+    public BookInspectionCommand toCommand(BookInspectionRequest request, String coverUrl) {
         return new BookInspectionCommand(
                 request.txtFile(),
                 request.title(),
                 request.description(),
-                request.coverUrl(),
+                coverUrl,
                 request.price(),
                 request.identificationNumber()
         );

--- a/src/main/java/com/speaktext/backend/book/inspection/presentation/BookInspectionController.java
+++ b/src/main/java/com/speaktext/backend/book/inspection/presentation/BookInspectionController.java
@@ -4,7 +4,6 @@ import com.speaktext.backend.auth.presentation.anotation.Admin;
 import com.speaktext.backend.auth.presentation.anotation.Author;
 import com.speaktext.backend.book.inspection.application.BookInspectionService;
 import com.speaktext.backend.book.inspection.application.dto.BookInspectionMetaResponse;
-import com.speaktext.backend.book.inspection.application.mapper.BookInspectionMapper;
 import com.speaktext.backend.book.inspection.presentation.dto.BookInspectionRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -20,17 +19,13 @@ import java.util.List;
 public class BookInspectionController {
 
     private final BookInspectionService bookInspectionService;
-    private final BookInspectionMapper bookInspectionMapper;
 
     @PostMapping("/inspection")
     public ResponseEntity<Void> requestPendingBook(
             @Valid @ModelAttribute BookInspectionRequest request,
             @Author Long authorId
     ) {
-        bookInspectionService.requestInspection(
-            bookInspectionMapper.toCommand(request),
-            authorId
-        );
+        bookInspectionService.requestInspection(request, authorId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/speaktext/backend/book/inspection/presentation/dto/BookInspectionRequest.java
+++ b/src/main/java/com/speaktext/backend/book/inspection/presentation/dto/BookInspectionRequest.java
@@ -10,7 +10,7 @@ public record BookInspectionRequest(
     @NotNull MultipartFile txtFile,
     @NotBlank String title,
     @NotBlank String description,
-    @NotBlank String coverUrl,
+    @NotNull MultipartFile coverImage,
     @NotNull BigDecimal price,
     @NotNull String identificationNumber
 ) {}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #79 

## 📝작업 내용

> coverImage를 저장 후 coverUrl을 DB에 저장하는 기능 구현
저장 클래스는 추상화하여 추후 대체 가능하도록 구현
프론트 쪽도 coverUrl이 아닌 coverImage를 업로드하도록 수정
